### PR TITLE
Fix control checkbox selector

### DIFF
--- a/src/ui/events.ts
+++ b/src/ui/events.ts
@@ -162,7 +162,7 @@ function bindControlSynchronizers(state: SimulationState, callbacks: SimulationE
         callbacks.runSimulationFrame();
     });
 
-    document.querySelectorAll('#controls input[type="checkbox"]').forEach(element => {
+    document.querySelectorAll('.controls input[type="checkbox"]').forEach(element => {
         element.addEventListener('change', () => {
             const checkbox = element as HTMLInputElement;
             if (checkbox.id.startsWith('show')) {


### PR DESCRIPTION
## Summary
- update the checkbox query selector in `bindControlSynchronizers` to target the `.controls` panel so all checkboxes are bound correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc241d57a8832986f9906076ac90ba