### PR TITLE
Improve seasonal temperature curves

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -21,6 +21,8 @@ export const FOG_DIFFUSION_RATE = 0.4;
 export const EPSILON = 1e-6;
 
 export const MONTHLY_TEMPS = [-10, -8, -3, 2, 8, 13, 15, 15, 8, 2, -4, -9];
+export const MONTHLY_DAYLIGHT_HOURS = [8.1, 9.4, 11.6, 13.7, 15.3, 16.1, 15.8, 14.0, 12.2, 10.1, 8.6, 7.9];
+export const MONTHLY_DIURNAL_VARIATION = [4.5, 5.0, 6.5, 8.0, 9.5, 10.5, 10.0, 8.5, 6.5, 5.5, 4.5, 4.0];
 
 export const LAND_TYPE_MAP: Record<string, number> = {
   grassland: LAND_TYPES.GRASSLAND,

--- a/src/simulation/temperature.ts
+++ b/src/simulation/temperature.ts
@@ -1,16 +1,50 @@
-import { MONTHLY_TEMPS } from '../shared/constants';
+import {
+  MONTHLY_DAYLIGHT_HOURS,
+  MONTHLY_DIURNAL_VARIATION,
+  MONTHLY_TEMPS,
+} from '../shared/constants';
+
+const EVENING_WARMTH_FRACTION = 0.15;
 
 export function calculateBaseTemperature(month: number, hour: number): number {
-  const monthTemp = MONTHLY_TEMPS[month - 1];
-  const isDayTime = hour >= 6 && hour <= 18;
+  const monthIndex = Math.min(
+    Math.max(Math.floor(month) - 1, 0),
+    MONTHLY_TEMPS.length - 1,
+  );
 
-  if (isDayTime) {
-    const hoursSinceSunrise = hour - 6;
-    const hourModifier = Math.sin((hoursSinceSunrise / 12) * Math.PI) * 6;
-    return monthTemp + hourModifier;
+  const averageTemp = MONTHLY_TEMPS[monthIndex];
+  const daylightHours = MONTHLY_DAYLIGHT_HOURS[monthIndex];
+  const diurnalRange = MONTHLY_DIURNAL_VARIATION[monthIndex];
+
+  const sunrise = 12 - daylightHours / 2;
+  const sunset = 12 + daylightHours / 2;
+  const midday = (sunrise + sunset) / 2;
+  const totalNightHours = Math.max(24 - daylightHours, 0.1);
+
+  const maxTemp = averageTemp + diurnalRange / 2;
+  const minTemp = averageTemp - diurnalRange / 2;
+  const eveningTemp = averageTemp + diurnalRange * EVENING_WARMTH_FRACTION;
+
+  const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
+  const isDayTime = hour >= sunrise && hour <= sunset;
+
+  if (isDayTime && daylightHours > 0) {
+    if (hour <= midday) {
+      const riseDuration = Math.max(midday - sunrise, 0.1);
+      const progress = clamp01((hour - sunrise) / riseDuration);
+      const warmFactor = Math.sin((progress * Math.PI) / 2);
+      return minTemp + (maxTemp - minTemp) * warmFactor;
+    }
+
+    const setDuration = Math.max(sunset - midday, 0.1);
+    const progress = clamp01((hour - midday) / setDuration);
+    const coolFactor = Math.cos((progress * Math.PI) / 2);
+    return eveningTemp + (maxTemp - eveningTemp) * coolFactor;
   }
 
-  const nightHours = hour <= 6 ? hour + 6 : hour - 18;
-  const nightCooling = -2 - (nightHours / 12) * 2;
-  return monthTemp + nightCooling;
+  const hoursSinceSunset =
+    hour > sunset ? hour - sunset : hour + (24 - sunset);
+  const nightProgress = clamp01(hoursSinceSunset / totalNightHours);
+  const damping = Math.cos((nightProgress * Math.PI) / 2);
+  return minTemp + (eveningTemp - minTemp) * damping;
 }


### PR DESCRIPTION
## Summary
- add monthly daylight hours and diurnal range datasets for seasonal modelling
- update base temperature calculation to use month-specific daylight-driven curves

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc29b70aec8329863ef4af3d80f9ac