### PR TITLE
Refine base temperature curve

### DIFF
--- a/src/simulation/temperature.ts
+++ b/src/simulation/temperature.ts
@@ -5,16 +5,53 @@ import {
 } from '../shared/constants';
 
 const EVENING_WARMTH_FRACTION = 0.15;
+const PREDAWN_WARMTH_FRACTION = 0.35;
+const PREDAWN_WINDOW_HOURS = 2.5;
+const SEASONAL_LAG_MONTHS = 0.6;
+const NIGHT_COOLING_EXPONENT = 0.85;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const clamp01 = (value: number) => clamp(value, 0, 1);
+
+const normalizeHour = (hour: number) => {
+  if (!Number.isFinite(hour)) {
+    return 0;
+  }
+  const wrapped = hour % 24;
+  return wrapped < 0 ? wrapped + 24 : wrapped;
+};
+
+const sampleMonthlyCycle = (monthValue: number, values: number[]) => {
+  if (values.length === 0) {
+    return 0;
+  }
+  const period = values.length;
+  const wrapped = ((monthValue % period) + period) % period;
+  const lowerIndex = Math.floor(wrapped);
+  const upperIndex = (lowerIndex + 1) % period;
+  const fraction = wrapped - lowerIndex;
+  const lowerValue = values[lowerIndex];
+  const upperValue = values[upperIndex];
+  return lowerValue + (upperValue - lowerValue) * fraction;
+};
+
+const smoothstep = (edge0: number, edge1: number, value: number) => {
+  if (edge1 === edge0) {
+    return 0;
+  }
+  const t = clamp01((value - edge0) / (edge1 - edge0));
+  return t * t * (3 - 2 * t);
+};
 
 export function calculateBaseTemperature(month: number, hour: number): number {
-  const monthIndex = Math.min(
-    Math.max(Math.floor(month) - 1, 0),
-    MONTHLY_TEMPS.length - 1,
-  );
+  const monthValue = Number.isFinite(month) ? month - 1 : 0;
+  const normalizedHour = normalizeHour(hour);
 
-  const averageTemp = MONTHLY_TEMPS[monthIndex];
-  const daylightHours = MONTHLY_DAYLIGHT_HOURS[monthIndex];
-  const diurnalRange = MONTHLY_DIURNAL_VARIATION[monthIndex];
+  const averageTemp = sampleMonthlyCycle(monthValue - SEASONAL_LAG_MONTHS, MONTHLY_TEMPS);
+  const daylightHours = clamp(sampleMonthlyCycle(monthValue, MONTHLY_DAYLIGHT_HOURS), 0, 24);
+  const diurnalRange = Math.max(0, sampleMonthlyCycle(monthValue, MONTHLY_DIURNAL_VARIATION));
 
   const sunrise = 12 - daylightHours / 2;
   const sunset = 12 + daylightHours / 2;
@@ -25,26 +62,48 @@ export function calculateBaseTemperature(month: number, hour: number): number {
   const minTemp = averageTemp - diurnalRange / 2;
   const eveningTemp = averageTemp + diurnalRange * EVENING_WARMTH_FRACTION;
 
-  const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
-  const isDayTime = hour >= sunrise && hour <= sunset;
+  const isDayTime = normalizedHour >= sunrise && normalizedHour <= sunset;
 
   if (isDayTime && daylightHours > 0) {
-    if (hour <= midday) {
+    if (normalizedHour <= midday) {
       const riseDuration = Math.max(midday - sunrise, 0.1);
-      const progress = clamp01((hour - sunrise) / riseDuration);
+      const progress = clamp01((normalizedHour - sunrise) / riseDuration);
       const warmFactor = Math.sin((progress * Math.PI) / 2);
       return minTemp + (maxTemp - minTemp) * warmFactor;
     }
 
     const setDuration = Math.max(sunset - midday, 0.1);
-    const progress = clamp01((hour - midday) / setDuration);
+    const progress = clamp01((normalizedHour - midday) / setDuration);
     const coolFactor = Math.cos((progress * Math.PI) / 2);
     return eveningTemp + (maxTemp - eveningTemp) * coolFactor;
   }
 
   const hoursSinceSunset =
-    hour > sunset ? hour - sunset : hour + (24 - sunset);
+    normalizedHour > sunset
+      ? normalizedHour - sunset
+      : normalizedHour + (24 - sunset);
   const nightProgress = clamp01(hoursSinceSunset / totalNightHours);
-  const damping = Math.cos((nightProgress * Math.PI) / 2);
-  return minTemp + (eveningTemp - minTemp) * damping;
+  const coolingBase = Math.cos((nightProgress * Math.PI) / 2);
+  const adjustedCooling = Math.pow(clamp01(coolingBase), NIGHT_COOLING_EXPONENT);
+  let nightTemperature = minTemp + (eveningTemp - minTemp) * adjustedCooling;
+
+  const hoursUntilSunrise =
+    normalizedHour < sunrise
+      ? sunrise - normalizedHour
+      : 24 - normalizedHour + sunrise;
+  const twilightWindow = Math.min(PREDAWN_WINDOW_HOURS, totalNightHours);
+
+  if (daylightHours > 0 && hoursUntilSunrise <= twilightWindow) {
+    const warmUpProgress = smoothstep(
+      0,
+      twilightWindow,
+      twilightWindow - hoursUntilSunrise,
+    );
+    const preDawnTarget =
+      minTemp + (maxTemp - minTemp) * PREDAWN_WARMTH_FRACTION;
+    nightTemperature =
+      nightTemperature * (1 - warmUpProgress) + preDawnTarget * warmUpProgress;
+  }
+
+  return nightTemperature;
 }


### PR DESCRIPTION
## Summary
- smooth the base temperature calculation with monthly interpolation, seasonal lag, and normalized hour handling
- add pre-dawn warming behaviour and adjustable night cooling for more gradual nocturnal transitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2b6b71bc8329b7314c109bd2a153