### PR TITLE
Adjust sun position to monthly day length

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,5 +1,9 @@
 import { GRID_SIZE } from './src/shared/constants';
 import {
+    getDaylightHoursFromMonthValue,
+    toMonthValue,
+} from './src/shared/seasonal';
+import {
     createSimulationState,
     resetGrid,
     resetVectorField,
@@ -64,10 +68,19 @@ function runSimulation(simDeltaTimeMinutes: number): void {
 
     updateSimulationClock(state.simulationTime);
 
-    const sunAltitude = Math.max(
-        0,
-        Math.sin(((currentHour + currentMinute / 60) - 6) * Math.PI / 12)
-    );
+    const timeOfDay = currentHour + currentMinute / 60;
+    const monthValue = toMonthValue(month);
+    const daylightHours = getDaylightHoursFromMonthValue(monthValue);
+    const sunriseHour = 12 - daylightHours / 2;
+    const sunsetHour = sunriseHour + daylightHours;
+    let sunAltitude = 0;
+
+    if (daylightHours > 0 && timeOfDay >= sunriseHour && timeOfDay <= sunsetHour) {
+        const dayProgress = (timeOfDay - sunriseHour) / daylightHours;
+        sunAltitude = Math.sin(dayProgress * Math.PI);
+    }
+
+    sunAltitude = Math.max(0, sunAltitude);
     const timeFactor = simDeltaTimeMinutes / 60;
 
     resetGrid(state.latentHeatEffect, 0);

--- a/src/shared/seasonal.ts
+++ b/src/shared/seasonal.ts
@@ -1,0 +1,35 @@
+import { MONTHLY_DAYLIGHT_HOURS } from './constants';
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export function toMonthValue(month: number): number {
+  if (!Number.isFinite(month)) {
+    return 0;
+  }
+  return month - 1;
+}
+
+export function sampleMonthlyCycle(monthValue: number, values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const period = values.length;
+  const wrapped = ((monthValue % period) + period) % period;
+  const lowerIndex = Math.floor(wrapped);
+  const upperIndex = (lowerIndex + 1) % period;
+  const fraction = wrapped - lowerIndex;
+  const lowerValue = values[lowerIndex];
+  const upperValue = values[upperIndex];
+  return lowerValue + (upperValue - lowerValue) * fraction;
+}
+
+export function getDaylightHoursFromMonthValue(monthValue: number): number {
+  const daylightHours = sampleMonthlyCycle(monthValue, MONTHLY_DAYLIGHT_HOURS);
+  return clamp(daylightHours, 0, 24);
+}
+
+export function getDaylightHoursForMonth(month: number): number {
+  const monthValue = toMonthValue(month);
+  return getDaylightHoursFromMonthValue(monthValue);
+}

--- a/src/simulation/temperature.ts
+++ b/src/simulation/temperature.ts
@@ -1,8 +1,9 @@
+import { MONTHLY_DIURNAL_VARIATION, MONTHLY_TEMPS } from '../shared/constants';
 import {
-  MONTHLY_DAYLIGHT_HOURS,
-  MONTHLY_DIURNAL_VARIATION,
-  MONTHLY_TEMPS,
-} from '../shared/constants';
+  getDaylightHoursFromMonthValue,
+  sampleMonthlyCycle,
+  toMonthValue,
+} from '../shared/seasonal';
 
 const EVENING_WARMTH_FRACTION = 0.15;
 const PREDAWN_WARMTH_FRACTION = 0.35;
@@ -23,20 +24,6 @@ const normalizeHour = (hour: number) => {
   return wrapped < 0 ? wrapped + 24 : wrapped;
 };
 
-const sampleMonthlyCycle = (monthValue: number, values: number[]) => {
-  if (values.length === 0) {
-    return 0;
-  }
-  const period = values.length;
-  const wrapped = ((monthValue % period) + period) % period;
-  const lowerIndex = Math.floor(wrapped);
-  const upperIndex = (lowerIndex + 1) % period;
-  const fraction = wrapped - lowerIndex;
-  const lowerValue = values[lowerIndex];
-  const upperValue = values[upperIndex];
-  return lowerValue + (upperValue - lowerValue) * fraction;
-};
-
 const smoothstep = (edge0: number, edge1: number, value: number) => {
   if (edge1 === edge0) {
     return 0;
@@ -46,11 +33,11 @@ const smoothstep = (edge0: number, edge1: number, value: number) => {
 };
 
 export function calculateBaseTemperature(month: number, hour: number): number {
-  const monthValue = Number.isFinite(month) ? month - 1 : 0;
+  const monthValue = toMonthValue(month);
   const normalizedHour = normalizeHour(hour);
 
   const averageTemp = sampleMonthlyCycle(monthValue - SEASONAL_LAG_MONTHS, MONTHLY_TEMPS);
-  const daylightHours = clamp(sampleMonthlyCycle(monthValue, MONTHLY_DAYLIGHT_HOURS), 0, 24);
+  const daylightHours = getDaylightHoursFromMonthValue(monthValue);
   const diurnalRange = Math.max(0, sampleMonthlyCycle(monthValue, MONTHLY_DIURNAL_VARIATION));
 
   const sunrise = 12 - daylightHours / 2;


### PR DESCRIPTION
## Summary
- add shared seasonal helpers to sample monthly cycles and daylight hours
- drive the simulation sun altitude by monthly daylight hours instead of a fixed 12-hour day
- reuse the shared daylight calculation inside the temperature model

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccffb86bdc8329b88bef045a722b93