### PR TITLE
Initialize wind vector field with base wind

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -6,13 +6,17 @@ import {
 import {
     createSimulationState,
     resetGrid,
-    resetVectorField,
     resizeCanvas,
     type SimulationState,
 } from './src/simulation/state';
 import { initializeEnvironment } from './src/simulation/environment';
 import { updateCloudDynamics } from './src/simulation/clouds';
-import { advectGrid, calculateDownslopeWinds } from './src/simulation/wind';
+import {
+    advectGrid,
+    applyBaseWindField,
+    calculateDownslopeWinds,
+    createVegetationDragGetter,
+} from './src/simulation/wind';
 import { updateFogSimulation } from './src/simulation/fog';
 import { initializeSoilMoisture } from './src/simulation/soil';
 import {
@@ -89,8 +93,9 @@ function runSimulation(simDeltaTimeMinutes: number): void {
         calculateDownslopeWinds(state, currentHour, windSpeed, windDir, windGustiness);
     } else {
         resetGrid(state.downSlopeWinds, 0);
-        resetVectorField(state.windVectorField);
         resetGrid(state.foehnEffect, 0);
+        const getVegetationDrag = createVegetationDragGetter(state);
+        applyBaseWindField(state, windSpeed, windDir, getVegetationDrag);
     }
 
     if (enableAdvection && timeFactor > 0) {


### PR DESCRIPTION
## Summary
- add helpers to derive vegetation drag and apply a base wind field to the vector grid before terrain effects are applied
- update downslope wind calculation to build on the base field and keep gust calculations tied to the base flow
- initialize the wind field with the base wind even when downslope effects are disabled in the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd1b922e00832984920ca7789c854b