### PR TITLE
Add missing Nimbostratus cloud type

### DIFF
--- a/src/simulation/weatherTypes.ts
+++ b/src/simulation/weatherTypes.ts
@@ -6,6 +6,7 @@ export const CLOUD_TYPES = {
   OROGRAPHIC: 4,
   CIRRUS: 5,
   ALTOSTRATUS: 6,
+  NIMBOSTRATUS: 7,
 } as const;
 
 export type CloudType = (typeof CLOUD_TYPES)[keyof typeof CLOUD_TYPES];


### PR DESCRIPTION
## Summary
- add the missing Nimbostratus entry to the cloud type enum used by precipitation calculations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2a4ffe148329a749318e09954dee