### PR TITLE
Add humidity visualization overlay and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,19 @@
                     <label for="showPrecipitation">Show Precipitation</label>
                 </div>
                 <div class="checkbox-group">
+                    <input type="checkbox" id="showHumidity">
+                    <label for="showHumidity">Show Relative Humidity</label>
+                </div>
+                <div class="legend" style="grid-template-columns: 1fr; margin: 6px 0 12px;">
+                    <div class="legend-item">
+                        <div
+                            class="legend-color"
+                            style="background: linear-gradient(90deg, #fef3c7 0%, #60a5fa 50%, #0f766e 100%);"
+                        ></div>
+                        <span style="font-size: 12px; color: #4a5568;">Humidity colors: dry → moist → saturated</span>
+                    </div>
+                </div>
+                <div class="checkbox-group">
                     <input type="checkbox" id="showSnowCover" checked>
                     <label for="showSnowCover">Show Snow Cover</label>
                 </div>

--- a/src/ui/controls.ts
+++ b/src/ui/controls.ts
@@ -24,6 +24,7 @@ export type VisualizationToggles = {
     showPrecipitation: boolean;
     showWind: boolean;
     showSnow: boolean;
+    showHumidity: boolean;
     heatmapPalette: HeatmapPalette;
 };
 
@@ -59,6 +60,7 @@ export function readVisualizationToggles(): VisualizationToggles {
         showPrecipitation: getElement<HTMLInputElement>('showPrecipitation').checked,
         showWind: getElement<HTMLInputElement>('showWindFlow').checked,
         showSnow: getElement<HTMLInputElement>('showSnowCover').checked,
+        showHumidity: getElement<HTMLInputElement>('showHumidity').checked,
         heatmapPalette: getElement<HTMLSelectElement>('heatmapPalette').value as HeatmapPalette,
     };
 }

--- a/src/ui/rendering.ts
+++ b/src/ui/rendering.ts
@@ -32,6 +32,12 @@ const HEATMAP_PALETTES: Record<HeatmapPalette, ColorStop[]> = {
     ],
 };
 
+const HUMIDITY_PALETTE: ColorStop[] = [
+    { value: 0, color: [254, 243, 199] },
+    { value: 0.5, color: [96, 165, 250] },
+    { value: 1, color: [15, 118, 110] },
+];
+
 function interpolateColor(stops: ColorStop[], value: number): [number, number, number] {
     if (value <= stops[0].value) return stops[0].color;
     if (value >= stops[stops.length - 1].value) return stops[stops.length - 1].color;
@@ -60,6 +66,12 @@ function getTemperatureColor(temp: number, palette: HeatmapPalette): string {
     return `rgba(${r}, ${g}, ${b}, 1)`;
 }
 
+function getHumidityColor(relativeHumidity: number): string {
+    const normalized = clamp(relativeHumidity, 0, 1);
+    const [r, g, b] = interpolateColor(HUMIDITY_PALETTE, normalized);
+    return `rgba(${r}, ${g}, ${b}, 1)`;
+}
+
 export function drawSimulation(
     ctx: CanvasRenderingContext2D | null,
     state: SimulationState,
@@ -76,6 +88,7 @@ export function drawSimulation(
         showPrecipitation,
         showWind,
         showSnow,
+        showHumidity,
         heatmapPalette,
     } = toggles;
 
@@ -103,6 +116,18 @@ export function drawSimulation(
             for (let x = 0; x < GRID_SIZE; x++) {
                 const color = getTemperatureColor(state.temperature[y][x], heatmapPalette);
                 ctx.globalAlpha = 0.6;
+                ctx.fillStyle = color;
+                ctx.fillRect(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
+            }
+        }
+        ctx.globalAlpha = 1.0;
+    }
+
+    if (showHumidity) {
+        ctx.globalAlpha = 0.45;
+        for (let y = 0; y < GRID_SIZE; y++) {
+            for (let x = 0; x < GRID_SIZE; x++) {
+                const color = getHumidityColor(state.humidity[y][x]);
                 ctx.fillStyle = color;
                 ctx.fillRect(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
             }


### PR DESCRIPTION
## Summary
- add a humidity checkbox and legend entry to the visualization controls and wire it into toggle reading
- extend the renderer with a humidity color palette that draws when the new toggle is enabled

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2fbec8fc8329b9b9da4aaf8ca09a