### PR TITLE
Refine fog simulation balance

### DIFF
--- a/src/simulation/fog.ts
+++ b/src/simulation/fog.ts
@@ -10,6 +10,8 @@ import {
 import type { SimulationState } from './state';
 import { clamp, computeBoundaryDamping, isInBounds } from './utils';
 
+const MAX_HOURLY_FOG_RATE = 0.6;
+
 export function updateFogSimulation(
   state: SimulationState,
   hour: number,
@@ -27,31 +29,70 @@ export function updateFogSimulation(
       let formationRate = 0;
       let dissipationRate = 0;
 
+      const wind = state.windVectorField[y][x];
+      const currentFog = state.fogDensity[y][x];
+      const relativeHumidity = clamp(state.humidity[y][x], 0, 1);
+      const dewPointDiff = state.dewPoint[y][x] - state.temperature[y][x];
+      const saturationFactor = clamp((dewPointDiff + 3) / 7, 0, 1);
+      const calmFactor = clamp((3 - wind.speed) / 3, 0, 1);
+      const soilMoisture = clamp(state.soilMoisture[y][x], 0, 1);
+      const hillshade = clamp(state.hillshade[y][x], 0, 1);
+
       if (state.inversionStrength > 0 && state.elevation[y][x] < state.inversionHeight) {
-        const depth = (state.inversionHeight - state.elevation[y][x]) / 100;
-        formationRate += state.inversionStrength * depth * 0.5;
+        const depth = Math.max(0, state.inversionHeight - state.elevation[y][x]);
+        const normalizedDepth = clamp(depth / 120, 0, 1);
+        formationRate += state.inversionStrength * normalizedDepth * (0.25 + calmFactor * 0.45);
       }
 
-      if (state.temperature[y][x] < state.dewPoint[y][x] + 2) {
-        const saturation = (state.dewPoint[y][x] + 2 - state.temperature[y][x]) / 4;
-        formationRate += saturation * state.humidity[y][x];
+      if (dewPointDiff >= -3) {
+        const dewBonus = clamp((dewPointDiff + 3) / 6, 0, 1);
+        const humidityBoost = 0.35 + relativeHumidity * 0.65;
+        formationRate += dewBonus * humidityBoost * (0.5 + calmFactor * 0.5);
       }
 
-      if (sunAltitude <= 0 && state.waterDistance[y][x] < 5) {
-        formationRate += ((5 - state.waterDistance[y][x]) / 5) * 0.3 * (1 - state.windVectorField[y][x].speed / 20);
+      formationRate += soilMoisture * 0.05 * (0.6 + saturationFactor * 0.4);
+
+      if (state.snowDepth[y][x] > 0) {
+        const snowFactor = clamp(state.snowDepth[y][x] / 80, 0, 0.12);
+        formationRate += snowFactor * (0.4 + calmFactor * 0.6);
+      }
+
+      if (state.waterDistance[y][x] < 8) {
+        const waterFactor = clamp((8 - state.waterDistance[y][x]) / 8, 0, 1);
+        const nocturnalBoost = sunAltitude <= 0 ? 1.2 : 0.6;
+        formationRate += waterFactor * (0.15 + relativeHumidity * 0.25) * nocturnalBoost * (0.4 + calmFactor * 0.6);
+      }
+
+      if (wind.speed < 2) {
+        formationRate += (2 - wind.speed) * 0.08 * (0.3 + saturationFactor * 0.7);
       }
 
       if (sunAltitude > 0) {
-        dissipationRate += sunAltitude * FOG_SUN_DISSIPATION;
+        const shading = 1 - hillshade;
+        dissipationRate += sunAltitude * FOG_SUN_DISSIPATION * (0.7 + shading * 0.6);
       }
 
-      dissipationRate += state.windVectorField[y][x].speed * FOG_WIND_DISSIPATION;
+      dissipationRate += wind.speed * FOG_WIND_DISSIPATION * (1 + wind.speed / 15);
 
-      if (state.temperature[y][x] > state.dewPoint[y][x]) {
-        dissipationRate += (state.temperature[y][x] - state.dewPoint[y][x]) * FOG_TEMP_DISSIPATION;
+      if (dewPointDiff < 0) {
+        dissipationRate += -dewPointDiff * FOG_TEMP_DISSIPATION * (0.7 + (1 - relativeHumidity) * 0.6);
       }
 
-      fogChangeRate[y][x] = formationRate - dissipationRate;
+      dissipationRate += (1 - relativeHumidity) * 0.15;
+
+      if (state.downSlopeWinds[y][x] > 0) {
+        dissipationRate += state.downSlopeWinds[y][x] * 0.12;
+      }
+
+      if (currentFog > 0.6) {
+        dissipationRate += (currentFog - 0.6) * 0.5;
+      }
+
+      if (wind.speed >= 6) {
+        dissipationRate += (wind.speed - 6) * 0.08;
+      }
+
+      fogChangeRate[y][x] = clamp(formationRate - dissipationRate, -MAX_HOURLY_FOG_RATE, MAX_HOURLY_FOG_RATE);
     }
   }
 


### PR DESCRIPTION
## Summary
- incorporate humidity, ground moisture, and snow cover signals when calculating fog formation
- tune dissipation rates to react to sunlight, wind, and downslope flows while clamping hourly changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd6c1d97108329b5c4ce36cee6097b