### PR TITLE
Refine simulation state typing and defaults

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -33,6 +33,7 @@ import {
 } from './src/ui/controls';
 import { drawSimulation } from './src/ui/rendering';
 import { setupEventListeners, type SimulationEventCallbacks } from './src/ui/events';
+import { CLOUD_TYPES, PRECIP_TYPES } from './src/simulation/weatherTypes';
 
 // ===== GLOBAL STATE =====
 const canvas = document.getElementById('canvas') as HTMLCanvasElement;
@@ -118,9 +119,9 @@ function runSimulation(simDeltaTimeMinutes: number): void {
         resetGrid(state.cloudOpticalDepth, 0);
         resetGrid(state.cloudBase, 0);
         resetGrid(state.cloudTop, 0);
-        resetGrid(state.cloudType, 0);
+        resetGrid(state.cloudType, CLOUD_TYPES.NONE);
         resetGrid(state.precipitation, 0);
-        resetGrid(state.precipitationType, 0);
+        resetGrid(state.precipitationType, PRECIP_TYPES.NONE);
         resetGrid(state.thermalStrength, 0);
         resetGrid(state.convectiveEnergy, 0);
         resetGrid(state.iceContent, 0);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,4 +1,4 @@
-import { LAND_TYPES, SOIL_TYPES } from './types';
+import { LAND_TYPES, type LandType, SOIL_TYPES, type SoilType } from './types';
 
 export const GRID_SIZE = 200;
 export const CELL_SIZE = 6;
@@ -24,20 +24,20 @@ export const MONTHLY_TEMPS = [-6, -4, 1, 8, 14, 18, 20, 19, 14, 8, 2, -3];
 export const MONTHLY_DAYLIGHT_HOURS = [8.6, 9.7, 11.7, 13.8, 15.2, 16.0, 15.4, 13.8, 11.9, 10.3, 8.9, 8.2];
 export const MONTHLY_DIURNAL_VARIATION = [4.0, 4.5, 6.0, 7.5, 9.0, 10.0, 9.2, 7.8, 6.2, 5.0, 4.3, 3.8];
 
-export const LAND_TYPE_MAP: Record<string, number> = {
+export const LAND_TYPE_MAP = {
   grassland: LAND_TYPES.GRASSLAND,
   forest: LAND_TYPES.FOREST,
   water: LAND_TYPES.WATER,
   urban: LAND_TYPES.URBAN,
   settlement: LAND_TYPES.SETTLEMENT,
-};
+} as const satisfies Record<string, LandType>;
 
-export const SOIL_TYPE_MAP: Record<string, number> = {
+export const SOIL_TYPE_MAP = {
   loam: SOIL_TYPES.LOAM,
   sand: SOIL_TYPES.SAND,
   clay: SOIL_TYPES.CLAY,
   rock: SOIL_TYPES.ROCK,
-};
+} as const satisfies Record<string, SoilType>;
 
 export const WATER_PROPERTIES = {
   name: 'Water',

--- a/src/simulation/clouds.ts
+++ b/src/simulation/clouds.ts
@@ -1,13 +1,13 @@
 import { CELL_SIZE, GRID_SIZE } from '../shared/constants';
 import { LAND_TYPES, SOIL_TYPES } from '../shared/types';
 import type { SimulationState } from './state';
-import { CLOUD_TYPES, PRECIP_TYPES } from './weatherTypes';
+import { CLOUD_TYPES, type CloudType, PRECIP_TYPES, type PrecipitationType } from './weatherTypes';
 import { clamp, getThermalProperties, isInBounds } from './utils';
 import { calculateBaseTemperature } from './temperature';
 
 type ConvectiveClouds = {
   development: number;
-  type: number;
+  type: CloudType;
   cape: number;
   thermalStrength: number;
 };
@@ -21,7 +21,7 @@ type CloudMicrophysics = {
 
 type PrecipitationResult = {
   rate: number;
-  type: number;
+  type: PrecipitationType;
 };
 
 type CloudRadiation = {
@@ -121,7 +121,7 @@ function calculatePrecipitation(
   const localCloudType = state.cloudType[y][x];
 
   let precipRate = 0;
-  let precipType = PRECIP_TYPES.NONE;
+  let precipType: PrecipitationType = PRECIP_TYPES.NONE;
 
   if (localCloudType === CLOUD_TYPES.CUMULONIMBUS) {
     precipRate = localCloudWater * 1.5;
@@ -208,7 +208,7 @@ function calculateConvectiveClouds(
   const cape = Math.max(0, thermal * state.humidity[y][x] * 100);
 
   let cloudDevelopment = 0;
-  let cloudTypeResult = CLOUD_TYPES.NONE;
+  let cloudTypeResult: CloudType = CLOUD_TYPES.NONE;
 
   if (cape > 500) {
     cloudDevelopment = Math.min(1, cape / 3000);

--- a/src/simulation/state.ts
+++ b/src/simulation/state.ts
@@ -1,12 +1,14 @@
 import { BASE_ELEVATION, CELL_SIZE, GRID_SIZE } from '../shared/constants';
+import { LAND_TYPES, type LandType, SOIL_TYPES, type SoilType } from '../shared/types';
+import { CLOUD_TYPES, type CloudType, PRECIP_TYPES, type PrecipitationType } from './weatherTypes';
 
 export type VectorFieldCell = { x: number; y: number; speed: number };
 
-type Grid = number[][];
+type Grid<T = number> = T[][];
 
 export type VectorField = VectorFieldCell[][];
 
-function createGrid(initialValue: number): Grid {
+function createGrid<T>(initialValue: T): Grid<T> {
   return Array.from({ length: GRID_SIZE }, () => Array(GRID_SIZE).fill(initialValue));
 }
 
@@ -17,43 +19,43 @@ function createVectorField(): VectorField {
 }
 
 export interface SimulationState {
-  elevation: Grid;
-  landCover: Grid;
-  soilType: Grid;
-  temperature: Grid;
-  hillshade: Grid;
-  waterDistance: Grid;
-  nearestWaterAreaId: Grid;
-  forestDistance: Grid;
-  nearestForestAreaId: Grid;
-  forestDepth: Grid;
-  urbanDistance: Grid;
-  contiguousAreas: Grid;
+  elevation: Grid<number>;
+  landCover: Grid<LandType>;
+  soilType: Grid<SoilType>;
+  temperature: Grid<number>;
+  hillshade: Grid<number>;
+  waterDistance: Grid<number>;
+  nearestWaterAreaId: Grid<number>;
+  forestDistance: Grid<number>;
+  nearestForestAreaId: Grid<number>;
+  forestDepth: Grid<number>;
+  urbanDistance: Grid<number>;
+  contiguousAreas: Grid<number>;
   areasizes: Map<number, number>;
   inversionHeight: number;
   inversionStrength: number;
-  fogDensity: Grid;
-  downSlopeWinds: Grid;
+  fogDensity: Grid<number>;
+  downSlopeWinds: Grid<number>;
   windVectorField: VectorField;
-  foehnEffect: Grid;
-  inversionAndDownslopeRate: Grid;
-  soilMoisture: Grid;
-  soilTemperature: Grid;
-  cloudCoverage: Grid;
-  cloudBase: Grid;
-  cloudTop: Grid;
-  cloudType: Grid;
-  cloudOpticalDepth: Grid;
-  precipitation: Grid;
-  precipitationType: Grid;
-  humidity: Grid;
-  dewPoint: Grid;
-  convectiveEnergy: Grid;
-  thermalStrength: Grid;
-  cloudWater: Grid;
-  iceContent: Grid;
-  latentHeatEffect: Grid;
-  snowDepth: Grid;
+  foehnEffect: Grid<number>;
+  inversionAndDownslopeRate: Grid<number>;
+  soilMoisture: Grid<number>;
+  soilTemperature: Grid<number>;
+  cloudCoverage: Grid<number>;
+  cloudBase: Grid<number>;
+  cloudTop: Grid<number>;
+  cloudType: Grid<CloudType>;
+  cloudOpticalDepth: Grid<number>;
+  precipitation: Grid<number>;
+  precipitationType: Grid<PrecipitationType>;
+  humidity: Grid<number>;
+  dewPoint: Grid<number>;
+  convectiveEnergy: Grid<number>;
+  thermalStrength: Grid<number>;
+  cloudWater: Grid<number>;
+  iceContent: Grid<number>;
+  latentHeatEffect: Grid<number>;
+  snowDepth: Grid<number>;
   currentBrush: string;
   currentBrushCategory: string;
   brushSize: number;
@@ -69,8 +71,8 @@ export interface SimulationState {
 export function createSimulationState(): SimulationState {
   return {
     elevation: createGrid(BASE_ELEVATION),
-    landCover: createGrid(0),
-    soilType: createGrid(0),
+    landCover: createGrid(LAND_TYPES.GRASSLAND),
+    soilType: createGrid(SOIL_TYPES.LOAM),
     temperature: createGrid(20),
     hillshade: createGrid(1),
     waterDistance: createGrid(Number.POSITIVE_INFINITY),
@@ -93,10 +95,10 @@ export function createSimulationState(): SimulationState {
     cloudCoverage: createGrid(0),
     cloudBase: createGrid(0),
     cloudTop: createGrid(0),
-    cloudType: createGrid(0),
+    cloudType: createGrid(CLOUD_TYPES.NONE),
     cloudOpticalDepth: createGrid(0),
     precipitation: createGrid(0),
-    precipitationType: createGrid(0),
+    precipitationType: createGrid(PRECIP_TYPES.NONE),
     humidity: createGrid(0.5),
     dewPoint: createGrid(10),
     convectiveEnergy: createGrid(0),
@@ -118,7 +120,7 @@ export function createSimulationState(): SimulationState {
   };
 }
 
-export function resetGrid(grid: Grid, value: number): void {
+export function resetGrid<T>(grid: Grid<T>, value: T): void {
   for (let y = 0; y < GRID_SIZE; y++) {
     grid[y].fill(value);
   }

--- a/src/simulation/utils.ts
+++ b/src/simulation/utils.ts
@@ -8,7 +8,7 @@ import {
   URBAN_PROPERTIES,
   WATER_PROPERTIES,
 } from '../shared/constants';
-import { LAND_TYPES, SOIL_TYPES } from '../shared/types';
+import { LAND_TYPES, type LandType, SOIL_TYPES, type SoilType } from '../shared/types';
 import type { SimulationState } from './state';
 
 export function clamp(value: number, min: number, max: number): number {
@@ -44,12 +44,18 @@ export function getThermalProperties(state: SimulationState, x: number, y: numbe
   return SOIL_PROPERTIES[soilType] ?? SOIL_PROPERTIES[SOIL_TYPES.LOAM];
 }
 
-export function resolveLandType(tileValue: string): number | undefined {
-  return LAND_TYPE_MAP[tileValue];
+export function resolveLandType(tileValue: string): LandType | undefined {
+  if (tileValue in LAND_TYPE_MAP) {
+    return LAND_TYPE_MAP[tileValue as keyof typeof LAND_TYPE_MAP];
+  }
+  return undefined;
 }
 
-export function resolveSoilType(tileValue: string): number | undefined {
-  return SOIL_TYPE_MAP[tileValue];
+export function resolveSoilType(tileValue: string): SoilType | undefined {
+  if (tileValue in SOIL_TYPE_MAP) {
+    return SOIL_TYPE_MAP[tileValue as keyof typeof SOIL_TYPE_MAP];
+  }
+  return undefined;
 }
 
 export function getLandColor(state: SimulationState, x: number, y: number, showSoil: boolean): string {


### PR DESCRIPTION
## Summary
- tighten `SimulationState` typing by using generic grids and enum defaults for land cover, soil, and weather fields
- align reset logic and shared maps with typed land and soil lookups
- update cloud calculations to respect the refined precipitation and cloud type unions

## Testing
- npx tsc --noEmit
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd74339ea48329b3290c4210ce6ae8