### PR TITLE
Fix diffusion timing and sun altitude interpretation

### DIFF
--- a/src/simulation/clouds.ts
+++ b/src/simulation/clouds.ts
@@ -515,7 +515,8 @@ export function calculateCloudRadiation(
 ): CloudRadiation {
   let solarTransmission = 1;
   if (state.cloudCoverage[y][x] > 0) {
-    const opticalPath = state.cloudOpticalDepth[y][x] / Math.max(0.1, Math.sin(sunAltitude));
+    const sinAltitude = clamp(sunAltitude, 0, 1);
+    const opticalPath = state.cloudOpticalDepth[y][x] / Math.max(0.1, sinAltitude);
     solarTransmission =
       1 - state.cloudCoverage[y][x] + state.cloudCoverage[y][x] * Math.exp(-opticalPath);
   }


### PR DESCRIPTION
## Summary
- prevent thermal diffusion from running when the simulation time factor is zero and scale the diffusion rate with time progression
- interpret sunAltitude values as sine-based intensity in solar and cloud calculations to restore proper daytime heating

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb1a6cc8c83299e41a160a85805f4