### PR TITLE
Fix simulation timing and thermodynamic bugs

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -67,7 +67,7 @@ function runSimulation(simDeltaTimeMinutes: number): void {
     } = readSimulationControls();
 
     const totalMinutesInDay = 24 * 60;
-    const normalizedTime = state.simulationTime % totalMinutesInDay;
+    const normalizedTime = ((state.simulationTime % totalMinutesInDay) + totalMinutesInDay) % totalMinutesInDay;
     const currentHour = Math.floor(normalizedTime / 60);
     const currentMinute = Math.floor(normalizedTime % 60);
 

--- a/src/simulation/clouds.ts
+++ b/src/simulation/clouds.ts
@@ -494,7 +494,7 @@ export function updateCloudDynamics(
         if (precip.type === PRECIP_TYPES.SNOW) {
           const snowAccumulation = precipRate * 10 * timeFactor;
           state.snowDepth[y][x] += snowAccumulation;
-          state.latentHeatEffect[y][x] += precipRate * 0.8;
+          state.latentHeatEffect[y][x] += precipRate * 0.8 * timeFactor;
         } else {
           const thermalProps = getThermalProperties(state, x, y);
           const infiltration = Math.min(precipRate * timeFactor, 1 - state.soilMoisture[y][x]);

--- a/src/simulation/environment.ts
+++ b/src/simulation/environment.ts
@@ -200,7 +200,7 @@ export function calculateContiguousAreas(state: SimulationState): void {
   state.contiguousAreas = Array(GRID_SIZE)
     .fill(null)
     .map(() => Array(GRID_SIZE).fill(0));
-  state.areasizes = new Map();
+  state.areaSizes = new Map();
   let areaId = 0;
   const visited = Array(GRID_SIZE)
     .fill(null)
@@ -235,7 +235,7 @@ export function calculateContiguousAreas(state: SimulationState): void {
       }
     }
 
-    state.areasizes.set(areaId, cells.length);
+    state.areaSizes.set(areaId, cells.length);
     return cells;
   }
 

--- a/src/simulation/fog.ts
+++ b/src/simulation/fog.ts
@@ -80,8 +80,8 @@ export function updateFogSimulation(
 
       dissipationRate += (1 - relativeHumidity) * 0.15;
 
-      if (state.downSlopeWinds[y][x] > 0) {
-        dissipationRate += state.downSlopeWinds[y][x] * 0.12;
+      if (state.downSlopeWinds[y][x] < 0) {
+        dissipationRate += Math.abs(state.downSlopeWinds[y][x]) * 0.12;
       }
 
       if (currentFog > 0.6) {

--- a/src/simulation/physics.ts
+++ b/src/simulation/physics.ts
@@ -296,8 +296,9 @@ export function updateThermodynamics(state: SimulationState, options: Thermodyna
 
                 airEnergyBalance += state.inversionAndDownslopeRate[y][x];
 
-                if (state.latentHeatEffect[y][x] > 0) {
-                    airEnergyBalance += state.latentHeatEffect[y][x] / timeFactor;
+                const latentEffect = state.latentHeatEffect[y][x];
+                if (latentEffect !== 0) {
+                    airEnergyBalance += latentEffect;
                 }
 
                 const humidity = clamp(state.humidity[y][x], 0, 1);

--- a/src/simulation/state.ts
+++ b/src/simulation/state.ts
@@ -31,7 +31,7 @@ export interface SimulationState {
   forestDepth: Grid<number>;
   urbanDistance: Grid<number>;
   contiguousAreas: Grid<number>;
-  areasizes: Map<number, number>;
+  areaSizes: Map<number, number>;
   inversionHeight: number;
   inversionStrength: number;
   fogDensity: Grid<number>;
@@ -82,7 +82,7 @@ export function createSimulationState(): SimulationState {
     forestDepth: createGrid(0),
     urbanDistance: createGrid(Number.POSITIVE_INFINITY),
     contiguousAreas: createGrid(0),
-    areasizes: new Map<number, number>(),
+    areaSizes: new Map<number, number>(),
     inversionHeight: 0,
     inversionStrength: 0,
     fogDensity: createGrid(0),

--- a/src/ui/controls.ts
+++ b/src/ui/controls.ts
@@ -171,10 +171,11 @@ export function updateInversionDisplay(state: SimulationState, enabled: boolean)
 export function updateSimulationClock(simulationMinutes: number): void {
     const safeMinutes = Number.isFinite(simulationMinutes) ? simulationMinutes : 0;
     const totalMinutesInDay = 24 * 60;
-    const normalizedTime = safeMinutes % totalMinutesInDay;
+    const normalizedTime = ((safeMinutes % totalMinutesInDay) + totalMinutesInDay) % totalMinutesInDay;
     const currentHour = Math.floor(normalizedTime / 60);
     const currentMinute = Math.floor(normalizedTime % 60);
-    const day = Math.floor(safeMinutes / totalMinutesInDay) + 1;
+    const dayIndex = Math.floor(safeMinutes / totalMinutesInDay);
+    const day = Math.max(0, dayIndex) + 1;
 
     getElement<HTMLElement>('simDay').textContent = `Day ${day}`;
     getElement<HTMLElement>('simTime').textContent = `${String(currentHour).padStart(2, '0')}:${String(


### PR DESCRIPTION
## Summary
- normalize simulation time tracking so clock updates correctly even when the accumulated minutes dip below zero
- fix the latent heat integration so condensation energy scales with the current timestep instead of exploding on small frames
- ensure downslope winds dissipate fog using their actual strength and expose contiguous area sizes through the corrected `areaSizes` map

## Testing
- npm run build
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d05a1fc70c83298bf4467066b6d235