### PR TITLE
Add inspector for selected simulation grid cells

### DIFF
--- a/index.css
+++ b/index.css
@@ -514,6 +514,54 @@ input[type="range"]::-webkit-slider-thumb:hover {
     border-color: rgba(56, 189, 248, 0.35);
 }
 
+.stats.selected-cell {
+    gap: 12px;
+}
+
+.stats.selected-cell .inspector-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.inspector-placeholder {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.stats.selected-cell.has-selection .inspector-placeholder {
+    display: none;
+}
+
+.inspector-list {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.inspector-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 0.9rem;
+}
+
+.inspector-row dt {
+    margin: 0;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.inspector-row dd {
+    margin: 0;
+    color: var(--text-primary);
+    font-weight: 600;
+    text-align: right;
+}
+
 .stat-row {
     display: flex;
     justify-content: space-between;

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
     <div class="main-container">
         <div class="canvas-container">
-            <canvas id="canvas"></canvas>
+            <canvas id="canvas" tabindex="0" aria-label="Simulation grid. Click or use arrow keys to inspect cell data."></canvas>
             <div id="tooltip"></div>
         </div>
 
@@ -359,6 +359,11 @@
                                 <span class="stat-label">Avg. Snow Depth:</span>
                                 <span class="stat-value" id="avgSnowDepth">--</span>
                             </div>
+                        </div>
+
+                        <div class="stats selected-cell" id="cellInspector" aria-live="polite" aria-atomic="true">
+                            <h3 class="inspector-title">Selected Cell</h3>
+                            <p class="inspector-placeholder">Click or focus a cell to see detailed terrain and weather information.</p>
                         </div>
 
                         <div class="stats inversion" id="inversionInfo" style="display: none;">

--- a/src/simulation/state.ts
+++ b/src/simulation/state.ts
@@ -66,6 +66,9 @@ export interface SimulationState {
   simulationTime: number;
   simulationSpeed: number;
   lastFrameTime: number;
+  selectedCellX: number | null;
+  selectedCellY: number | null;
+  selectedCellTooltipHtml: string | null;
 }
 
 export function createSimulationState(): SimulationState {
@@ -117,6 +120,9 @@ export function createSimulationState(): SimulationState {
     simulationTime: 6 * 60,
     simulationSpeed: 10,
     lastFrameTime: typeof performance !== 'undefined' ? performance.now() : Date.now(),
+    selectedCellX: null,
+    selectedCellY: null,
+    selectedCellTooltipHtml: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- extend the simulation state to track the currently inspected cell and cache tooltip content
- add a persistent inspector panel in the sidebar with keyboard-accessible navigation for the canvas
- keep the inspector synchronized with data changes and clear it when the environment resets or invalidating layers toggle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d06603e91083299902b0be35ad06f5