### PR TITLE
Add manual time of day control for simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,12 @@
                             <span id="simDay">Day 1</span>, <span id="simTime">06:00</span>
                         </div>
                         <div class="control-group">
+                            <label for="timeOfDay">
+                                Time of Day: <span class="range-value" id="timeOfDayValue">06:00</span>
+                            </label>
+                            <input type="range" id="timeOfDay" min="0" max="1439" value="360" step="15">
+                        </div>
+                        <div class="control-group">
                             <label>Simulation Speed: <span class="range-value" id="speedValue">1x</span></label>
                             <input type="range" id="simSpeed" min="1" max="60" value="10" step="1">
                         </div>

--- a/index.tsx
+++ b/index.tsx
@@ -30,6 +30,7 @@ import {
     updateInversionDisplay,
     updateMetricsDisplay,
     updateSimulationClock,
+    updateTimeOfDayControl,
 } from './src/ui/controls';
 import { drawSimulation } from './src/ui/rendering';
 import { setupEventListeners, type SimulationEventCallbacks } from './src/ui/events';
@@ -72,6 +73,7 @@ function runSimulation(simDeltaTimeMinutes: number): void {
     const currentMinute = Math.floor(normalizedTime % 60);
 
     updateSimulationClock(state.simulationTime);
+    updateTimeOfDayControl(state.simulationTime);
 
     const timeOfDay = currentHour + currentMinute / 60;
     const monthValue = toMonthValue(month);
@@ -175,6 +177,18 @@ const eventCallbacks: SimulationEventCallbacks = {
     runSimulationFrame: () => runSimulation(0),
     redraw: () => drawSimulation(ctx, state, readVisualizationToggles()),
     initializeGrids,
+    seekToTimeOfDay: targetMinutes => {
+        const totalMinutesInDay = 24 * 60;
+        const normalizedTarget = ((targetMinutes % totalMinutesInDay) + totalMinutesInDay) % totalMinutesInDay;
+        const currentNormalized = ((state.simulationTime % totalMinutesInDay) + totalMinutesInDay) % totalMinutesInDay;
+        let deltaMinutes = normalizedTarget - currentNormalized;
+        if (deltaMinutes < 0) {
+            deltaMinutes += totalMinutesInDay;
+        }
+
+        state.simulationTime += deltaMinutes;
+        runSimulation(deltaMinutes);
+    },
 };
 
 setupEventListeners(state, canvas, tooltip, eventCallbacks);


### PR DESCRIPTION
## Summary
- add a time-of-day range input to the Simulation Control panel so users can scrub through a day
- keep the new slider, clock readout, and play/pause state synchronized with the simulation loop
- allow manual seeks to advance the model state immediately so cloud and inversion outputs refresh at the chosen minute

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0692a6318832989ad2a008cd5437a