### PR TITLE
Fix control synchronization and environmental calculations

### DIFF
--- a/src/simulation/climate.ts
+++ b/src/simulation/climate.ts
@@ -20,7 +20,7 @@ export function blendHumidityTowardsTarget(
   blendFactor: number,
 ): number {
   const safeCurrent = clamp(currentHumidity, 0, 1);
-  const safeTarget = clamp(targetHumidity, 0.01, 1);
+  const safeTarget = clamp(targetHumidity, 0, 1);
   const safeBlend = clamp(blendFactor, 0, 1);
   return safeCurrent + (safeTarget - safeCurrent) * safeBlend;
 }

--- a/src/simulation/environment.ts
+++ b/src/simulation/environment.ts
@@ -17,11 +17,11 @@ function clampGridIndex(value: number): number {
     return 0;
   }
 
-  const integerValue = Math.round(value);
-  if (integerValue <= 0) {
+  const integerValue = Math.floor(value);
+  if (integerValue < 0) {
     return 0;
   }
-  if (integerValue >= GRID_SIZE - 1) {
+  if (integerValue > GRID_SIZE - 1) {
     return GRID_SIZE - 1;
   }
   return integerValue;
@@ -57,11 +57,12 @@ function fractionToGridIndex(fraction: number): number {
 }
 
 function scaleByGrid(fraction: number, minimum = 1): number {
-  const safeMinimum = isFiniteNumber(minimum) ? Math.max(1, Math.round(minimum)) : 1;
-  const safeFraction = isFiniteNumber(fraction) ? fraction : 0;
-  const scaled = Math.round(GRID_SIZE * safeFraction);
-  const safeScaled = isFiniteNumber(scaled) ? scaled : 0;
-  return Math.max(safeMinimum, safeScaled);
+  const safeMinimum = isFiniteNumber(minimum) ? Math.max(1, Math.ceil(minimum)) : 1;
+  const finiteFraction = isFiniteNumber(fraction) ? fraction : 0;
+  const normalizedFraction = normalizeFraction(finiteFraction);
+  const scaled = Math.round(GRID_SIZE * normalizedFraction);
+  const clampedScaled = Math.min(GRID_SIZE, Math.max(0, scaled));
+  return Math.min(Math.max(safeMinimum, clampedScaled), GRID_SIZE);
 }
 
 function generatePerlinNoise(): number[][] {

--- a/src/simulation/physics.ts
+++ b/src/simulation/physics.ts
@@ -405,13 +405,16 @@ export function calculateSimulationMetrics(state: SimulationState): SimulationMe
 
     const precipitationValues = state.precipitation.flat().filter(Number.isFinite);
     const totalPrecipitation =
-        precipitationValues.reduce((sum, value) => sum + value, 0) / totalCells;
+        precipitationValues.reduce((sum, value) => sum + value, 0) /
+        Math.max(1, precipitationValues.length);
 
     const cloudHeights = state.cloudTop.flat().filter(Number.isFinite);
     const maxCloudHeight = cloudHeights.length > 0 ? Math.max(...cloudHeights) : 0;
 
     const snowDepthValues = state.snowDepth.flat().filter(Number.isFinite);
-    const avgSnowDepth = snowDepthValues.reduce((sum, value) => sum + value, 0) / totalCells;
+    const avgSnowDepth =
+        snowDepthValues.reduce((sum, value) => sum + value, 0) /
+        Math.max(1, snowDepthValues.length);
 
     return {
         minTemperature,

--- a/src/ui/controls.ts
+++ b/src/ui/controls.ts
@@ -241,15 +241,17 @@ export function updateTimeOfDayControl(simulationMinutes: number): void {
     const label = document.getElementById('timeOfDayValue');
     const safeMinutes = Number.isFinite(simulationMinutes) ? simulationMinutes : 0;
     const normalizedTime = normalizeToDay(safeMinutes);
+    let displayMinutes = normalizedTime;
 
     if (slider) {
         const stepAligned = Math.round(normalizedTime / TIME_SLIDER_STEP_MINUTES) * TIME_SLIDER_STEP_MINUTES;
         const clamped = Math.min(Math.max(0, stepAligned), TOTAL_MINUTES_IN_DAY - 1);
         slider.value = clamped.toString();
+        displayMinutes = clamped;
     }
 
     if (label) {
-        label.textContent = formatTimeLabel(safeMinutes);
+        label.textContent = formatTimeLabel(displayMinutes);
     }
 }
 


### PR DESCRIPTION
## Summary
- clamp grid index calculations to avoid rounding up to invalid cells and normalize grid-scaling inputs before clamping to the canvas size
- keep the time-of-day slider label in sync with the snapped slider position for consistent UI feedback
- average precipitation and snow metrics over available data points and allow humidity targets down to 0%

## Testing
- npm run build
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d0eeb331f08329a0675c80198c27fd