### PR TITLE
Align base temperature with climate controls

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -155,6 +155,7 @@ function runSimulation(simDeltaTimeMinutes: number): void {
     updateThermodynamics(state, {
         month,
         hour: currentHour,
+        timeOfDay,
         sunAltitude,
         timeFactor,
         enableDiffusion,


### PR DESCRIPTION
## Summary
- include time-of-day information when running thermodynamics updates
- use climate-aware base temperatures when calculating turbulence and wind mixing
- align lapse-rate baseline with the climate controls so temperature offsets take effect

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0fdb8e3c08329af64a8d9c494b8e2