### PR TITLE
Make layout responsive and prevent overflow

### DIFF
--- a/index.css
+++ b/index.css
@@ -48,6 +48,7 @@ body {
     align-items: stretch;
     min-height: 100vh;
     line-height: 1.5;
+    overflow-x: hidden;
 }
 
 body::before {
@@ -61,7 +62,7 @@ body::before {
 
 .header {
     width: 100%;
-    padding: 32px 8vw 24px;
+    padding: 32px clamp(24px, 6vw, 96px) 24px;
     background: linear-gradient(120deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.55));
     border-bottom: 1px solid var(--border-soft);
     box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.1);
@@ -94,13 +95,15 @@ body::before {
 }
 
 .main-container {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) clamp(320px, 28vw, 420px);
+    align-items: start;
     flex: 1;
-    gap: 24px;
-    padding: 0 8vw 40px;
-    width: 100%;
-    max-width: 1600px;
+    gap: clamp(16px, 2.5vw, 32px);
+    padding: 0 clamp(24px, 6vw, 96px) 40px;
+    width: min(100%, 1600px);
     margin: 0 auto;
+    min-height: 0;
 }
 
 .canvas-container {
@@ -112,11 +115,15 @@ body::before {
     border: 1px solid var(--border-soft);
     box-shadow: var(--shadow-soft);
     backdrop-filter: blur(16px);
+    min-width: 0;
 }
 
 canvas {
     width: 100%;
+    max-width: 100%;
     display: block;
+    height: auto;
+    aspect-ratio: 1 / 1;
     border-radius: var(--radius-md);
     border: 1px solid rgba(148, 163, 184, 0.25);
     background: rgba(15, 23, 42, 0.4);
@@ -124,7 +131,9 @@ canvas {
 }
 
 .controls {
-    width: 420px;
+    width: auto;
+    max-width: 100%;
+    justify-self: stretch;
     background: linear-gradient(160deg, rgba(15, 23, 42, 0.8), rgba(30, 41, 59, 0.7));
     border-radius: var(--radius-lg);
     border: 1px solid var(--border-soft);
@@ -897,17 +906,17 @@ input[type="range"]::-webkit-slider-thumb:hover {
 
 @media (max-width: 1280px) {
     .main-container {
-        flex-direction: column;
-        padding: 0 5vw 40px;
+        grid-template-columns: minmax(0, 1fr);
+        padding: 0 clamp(20px, 5vw, 64px) 40px;
     }
 
     .controls {
         width: 100%;
-        max-height: unset;
+        justify-self: stretch;
     }
 
     .control-accordion {
-        max-height: 60vh;
+        max-height: none;
     }
 }
 
@@ -918,6 +927,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
 
     .main-container {
         padding: 0 24px 32px;
+        gap: 20px;
     }
 
     .canvas-container {


### PR DESCRIPTION
## Summary
- convert the main layout to a responsive grid so the canvas and control panels resize without forcing horizontal overflow
- allow the canvas container to shrink responsively, ensure the canvas scales with an enforced aspect ratio, and clamp padding for common screen sizes
- update responsive breakpoints to stack controls vertically on narrow viewports without truncating the accordion content

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d11a908ba88329bfd0b9ebc4121dc1